### PR TITLE
挨拶選択ページ、録音ページの実装

### DIFF
--- a/app/controllers/greetings_controller.rb
+++ b/app/controllers/greetings_controller.rb
@@ -1,0 +1,6 @@
+class GreetingsController < ApplicationController
+
+  def index
+    @greetings = Greeting.all
+  end
+end

--- a/app/controllers/greetings_controller.rb
+++ b/app/controllers/greetings_controller.rb
@@ -3,4 +3,8 @@ class GreetingsController < ApplicationController
   def index
     @greetings = Greeting.all
   end
+
+  def show
+    @greeting = Greeting.find(params[:id])
+  end
 end

--- a/app/models/greeting.rb
+++ b/app/models/greeting.rb
@@ -1,0 +1,4 @@
+class Greeting < ApplicationRecord
+  validates :phrase, length: { maximum: 50 }, presence: true
+  validates :subtitle, length: { maximum: 255 }
+end

--- a/app/views/greetings/index.html.erb
+++ b/app/views/greetings/index.html.erb
@@ -1,23 +1,19 @@
 <div class="container pt-3">
   <div class="row">
-    <div class="col-lg-10 offset-lg-1">
-      測定したい挨拶を選んでね
-    </div>
+    <h1>測定したい挨拶を選んでね</h1>
   </div>
   <div class="row">
     <div class="col-12">
-      <div class="row">
       <% if @greetings.present? %>
         <% @greetings.each do |greeting| %>
           <br>
           <%= greeting.subtitle %><br>
-          <%= greeting.phrase %><br>
+          <%= link_to greeting.phrase, greeting_path(greeting), class: 'btn btn-info' %><br>
           <br>
         <% end %>
       <% else %>
         <p>未登録</p>
       <% end %>
-      </div>
     </div>
   </div>
 </div>

--- a/app/views/greetings/index.html.erb
+++ b/app/views/greetings/index.html.erb
@@ -1,0 +1,23 @@
+<div class="container pt-3">
+  <div class="row">
+    <div class="col-lg-10 offset-lg-1">
+      測定したい挨拶を選んでね
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <div class="row">
+      <% if @greetings.present? %>
+        <% @greetings.each do |greeting| %>
+          <br>
+          <%= greeting.subtitle %><br>
+          <%= greeting.phrase %><br>
+          <br>
+        <% end %>
+      <% else %>
+        <p>未登録</p>
+      <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/greetings/show.html.erb
+++ b/app/views/greetings/show.html.erb
@@ -1,0 +1,32 @@
+<div class="container">
+  <div class="row">
+    <div class="col-md-4 offset-md-2">
+      <div class="card bg-info mb-3">
+        <div class="card-body">
+          <div class="row">
+            <p class= "text-start">
+              <%= @greeting.subtitle %>
+            </p>
+            <h1 class= "text-center">
+            <%= @greeting.phrase %>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="col-lg-8 offset-lg-2 text-center mb-3">
+      <h3>マスクフィルター</h3>
+      <p>音声加工によりマスク着用を想定した測定ができます。</p>
+      <div class="btn btn-dark">
+        ON
+      </div>
+      <div class="btn btn-outline-dark">
+        OFF
+      </div>
+    </div>
+    <div class="text-center">
+      <div class="btn btn-info">
+        録音開始！
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -5,6 +5,6 @@
   </div>
   <div class="text-center">
     <h1>あいさつマスター</h1>
-    <%= link_to 'はじめる', '#', class: 'btn btn-info' %>
+    <%= link_to 'はじめる', greetings_path, class: 'btn btn-info' %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root 'top#index'
+
+  resources :greetings, only: %i[index]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root 'top#index'
 
-  resources :greetings, only: %i[index]
+  resources :greetings, only: %i[index show]
 end

--- a/db/migrate/20220128061610_create_greetings.rb
+++ b/db/migrate/20220128061610_create_greetings.rb
@@ -1,0 +1,10 @@
+class CreateGreetings < ActiveRecord::Migration[6.1]
+  def change
+    create_table :greetings do |t|
+      t.string :phrase,   limit: 50, null: false
+      t.string :subtitle, limit: 255
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,25 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2022_01_28_061610) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "greetings", force: :cascade do |t|
+    t.string "phrase", limit: 50, null: false
+    t.string "subtitle", limit: 255
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+end


### PR DESCRIPTION
## 概要

下記通り、挨拶選択ページ及び録音ページを実装した
- Greetingモデルの作成
  - バリデーションの追加
- マイグレーション実行
  - NOT NULL制約、文字数制限の追加
- コントローラー作成、ルーティング設定
  - 一旦、index showのみ

## 確認方法

- [ ] Topページの`はじめる`を押下した時、挨拶選択ページに遷移する
- [ ] 挨拶選択ページで挨拶を選択した時、録音ページに遷移する

## コメント

仮デザインとする

close #7 
close #8 