### PR TITLE
結果保持しての登録機能追加後のエラー修正

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,7 +17,7 @@ class UsersController < ApplicationController
     @user = User.new(user_params)
     if @user.save
       auto_login(@user)
-      if result_params
+      if result_params.present?
         @result = Result.find(result_params[:result][:id])
         @result.update(user_id: current_user.id)
       end

--- a/app/views/results/show.html.slim
+++ b/app/views/results/show.html.slim
@@ -23,12 +23,13 @@
         | 結果をツイート
       .mt-1.text-sm
         | ※音声は公開されません
-    .ml-2
-      = link_to new_user_path(result_id: @result.id), class: 'btn-secondary mr-2' do
-        i.mr-1.fa-solid.fa-user-pen
-        | ユーザー登録
-      .mt-1.text-sm
-        | ※この結果が保持されます
+    = unless logged_in?
+      .ml-2
+        = link_to new_user_path(result_id: @result.id), class: 'btn-secondary mr-2' do
+          i.mr-1.fa-solid.fa-user-pen
+          | ユーザー登録
+        .mt-1.text-sm
+          | ※この結果が保持されます
   .mt-6
     = link_to 'もう一度測定', greeting_path(@greeting), class: 'border-gray-300 border-b-2 hover:text-gray-300 mr-2'
     = link_to '別の挨拶を測定', greetings_path, class: 'border-gray-300 border-b-2 hover:text-gray-300'


### PR DESCRIPTION
## 概要

結果保持してユーザー登録する機能を追加したが、それに伴いエラーが生じたため、修正した

## 詳細

- ユーザー登録後にトップページに遷移しない（エラー）
  - result_paramsが常にtrueを返していたため、present?で条件分岐させる
- ログイン済ユーザーでも、結果ページで「ユーザー登録ボタン」が表示される

close #98 